### PR TITLE
Escope overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Enforce $varName for jQuery assignment.
 
-A direct port of the `requireDollarBeforejQueryAssignment` rule from JSCS.
+Based on the `requireDollarBeforejQueryAssignment` rule from JSCS.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-dollar-sign",
-  "version": "0.0.5",
+  "version": "1.0.0",
   "description": "Enforce $varName for jQuery assignment.",
   "keywords": [
     "eslint",

--- a/rules/dollar-sign.js
+++ b/rules/dollar-sign.js
@@ -54,16 +54,21 @@ module.exports = function(context) {
 
 	function reportAllReferences(variable) {
 		var refs = collectReferenceIdentifiers(variable);
+		var autofix = true;
 		var i, id;
 
 		for (i = 0; i < refs.length; ++i) {
 			id = refs[i];
-
 			if (id.parent.type === 'Property' && id.parent.shorthand) {
-				continue;
+				// if any reference is used for a shorthand property, don't autofix
+				autofix = false;
+				break;
 			}
+		}
 
-			reportIdentifier(id, true);
+		for (i = 0; i < refs.length; ++i) {
+			id = refs[i];
+			reportIdentifier(id, autofix);
 		}
 	}
 

--- a/rules/dollar-sign.js
+++ b/rules/dollar-sign.js
@@ -96,7 +96,7 @@ module.exports = function(context) {
 			if (!variable.defs.length) continue;
 			def = variable.defs[0];
 
-			if (def.node.id.type === 'ObjectPattern' || def.node.id.type === 'ArrayPattern') continue;
+			if (!def.node.id || def.node.id.type === 'ObjectPattern' || def.node.id.type === 'ArrayPattern') continue;
 
 			if (
 				def.node.init ?

--- a/tests/dollar-sign.js
+++ b/tests/dollar-sign.js
@@ -367,13 +367,18 @@ ruleTester.run('dollar-sign', rule, {
 		// don't autofix object property keys
 		{
 			code: 'var x = $(".foo"); ({ x });',
-			output: 'var $x = $(".foo"); ({ x });',
+			output: 'var x = $(".foo"); ({ x });',
 			ecmaFeatures: { objectLiteralShorthandProperties: true },
 			errors: [{
 				message: errorMessage,
 				type: 'Identifier',
 				line: 1,
 				column: 5
+			}, {
+				message: errorMessage,
+				type: 'Identifier',
+				line: 1,
+				column: 23
 			}]
 		},
 		// autofix shadowed vars in child scopes

--- a/tests/dollar-sign.js
+++ b/tests/dollar-sign.js
@@ -197,7 +197,7 @@ ruleTester.run('dollar-sign', rule, {
 		// assignment on right hand side of object destructuring
 		{
 			code: 'var {foo} = {foo: $(".foo")}',
-			output: 'var {foo} = {$foo: $(".foo")}',
+			output: 'var {foo} = {foo: $(".foo")}',
 			ecmaFeatures: { destructuring: true },
 			errors: [{
 				message: errorMessage,
@@ -223,7 +223,7 @@ ruleTester.run('dollar-sign', rule, {
 		// basic jquery operator
 		{
 			code: 'var x = { foo: $() }',
-			output: 'var x = { $foo: $() }',
+			output: 'var x = { foo: $() }',
 			errors: [{
 				message: errorMessage,
 				type: 'Identifier',
@@ -234,7 +234,7 @@ ruleTester.run('dollar-sign', rule, {
 		// jquery operator with selector
 		{
 			code: 'var x = { foo: $(".foo") }',
-			output: 'var x = { $foo: $(".foo") }',
+			output: 'var x = { foo: $(".foo") }',
 			errors: [{
 				message: errorMessage,
 				type: 'Identifier',
@@ -245,7 +245,7 @@ ruleTester.run('dollar-sign', rule, {
 		// jquery operator with dollar and single quotes around selector
 		{
 			code: 'var $x = { foo: $(\'.foo\') }',
-			output: 'var $x = { $foo: $(\'.foo\') }',
+			output: 'var $x = { foo: $(\'.foo\') }',
 			errors: [{
 				message: errorMessage,
 				type: 'Identifier',
@@ -256,7 +256,7 @@ ruleTester.run('dollar-sign', rule, {
 		// keys besides the first
 		{
 			code: 'var x = { bar: 1, foo: $(".foo") }',
-			output: 'var x = { bar: 1, $foo: $(".foo") }',
+			output: 'var x = { bar: 1, foo: $(".foo") }',
 			errors: [{
 				message: errorMessage,
 				type: 'Identifier',
@@ -270,7 +270,7 @@ ruleTester.run('dollar-sign', rule, {
 		// basic jquery operator
 		{
 			code: 'this.x = $();',
-			output: 'this.$x = $();',
+			output: 'this.x = $();',
 			errors: [{
 				message: errorMessage,
 				type: 'Identifier',
@@ -281,7 +281,7 @@ ruleTester.run('dollar-sign', rule, {
 		// jquery operator with html
 		{
 			code: 'this.x = $("<p>foo</p>");',
-			output: 'this.$x = $("<p>foo</p>");',
+			output: 'this.x = $("<p>foo</p>");',
 			errors: [{
 				message: errorMessage,
 				type: 'Identifier',
@@ -292,7 +292,7 @@ ruleTester.run('dollar-sign', rule, {
 		// jquery operator with selector
 		{
 			code: 'this.x = $(".foo");',
-			output: 'this.$x = $(".foo");',
+			output: 'this.x = $(".foo");',
 			errors: [{
 				message: errorMessage,
 				type: 'Identifier',
@@ -303,7 +303,7 @@ ruleTester.run('dollar-sign', rule, {
 		// multi level object assignment without dollar
 		{
 			code: 'a.b.c = $()',
-			output: 'a.b.$c = $()',
+			output: 'a.b.c = $()',
 			errors: [{
 				message: errorMessage,
 				type: 'Identifier',

--- a/tests/dollar-sign.js
+++ b/tests/dollar-sign.js
@@ -73,6 +73,8 @@ ruleTester.run('dollar-sign', rule, {
 		'var x = 5; x = $(".foo");',
 		// late assignment with jQuery
 		'var $x; $x = $(".foo");',
+		// parameters
+		'(function(x) {});',
 
 		//// in object definition
 


### PR DESCRIPTION
- rewritten to use Escope instead of inspecting each variable assignment individually
- stop autofixing object properties (it's error-prone)
- autofix all var references instead of just the assignment

Fixes #7
